### PR TITLE
fix typo in backlight parameter variable name

### DIFF
--- a/driver/backlight.c
+++ b/driver/backlight.c
@@ -105,10 +105,10 @@ bool BACKLIGHT_IsOn()
 
 static uint8_t currentBrightness;
 
-void BACKLIGHT_SetBrightness(uint8_t brigtness)
+void BACKLIGHT_SetBrightness(uint8_t brightness)
 {
 	currentBrightness = brigtness;
-	PWM_PLUS0_CH0_COMP = (1 << brigtness) - 1;
+	PWM_PLUS0_CH0_COMP = (1 << brightness) - 1;
 	//PWM_PLUS0_SWLOAD = 1;
 }
 

--- a/driver/backlight.h
+++ b/driver/backlight.h
@@ -35,7 +35,7 @@ void BACKLIGHT_InitHardware();
 void BACKLIGHT_TurnOn();
 void BACKLIGHT_TurnOff();
 bool BACKLIGHT_IsOn();
-void BACKLIGHT_SetBrightness(uint8_t brigtness);
+void BACKLIGHT_SetBrightness(uint8_t brightness);
 uint8_t BACKLIGHT_GetBrightness(void);
 
 #endif


### PR DESCRIPTION
- fix typo in backlight.c and backlight.h